### PR TITLE
Change the default opts from nil to {} since it's about to be #dup'd

### DIFF
--- a/qpid-client/lib/rjack-qpid-client/qpid_jms_context.rb
+++ b/qpid-client/lib/rjack-qpid-client/qpid_jms_context.rb
@@ -165,7 +165,7 @@ module RJack::QpidClient
     # Serialize destination
     # {Addresses}[http://qpid.apache.org/books/0.14/Programming-In-Apache-Qpid/html/ch02s04.html]
     # (new format). Reference: section 2.4.3.5
-    def address_serialize( name, opts = nil )
+    def address_serialize( name, opts = {} )
       opts = opts.dup
       out = ( opts.delete( :address ) || name ).to_s
       subject = opts.delete( :subject )


### PR DESCRIPTION
Found an error like this in my logs:

```
TypeError: can't dup NilClass
                 dup at org/jruby/RubyKernel.java:1911
   address_serialize at /Users/matt/.rvm/gems/jruby-1.6.7.2/gems/rjack-qpid-client-0.14.1-java/lib/rjack-qpid-client/qpid_jms_context.rb:169
  lookup_destination at /Users/matt/.rvm/gems/jruby-1.6.7.2/gems/rjack-qpid-client-0.14.1-java/lib/rjack-qpid-client/qpid_jms_context.rb:131
```
