### PR TITLE
rjack-slf4j *_ex methods don't clobber the user's string

### DIFF
--- a/slf4j/lib/rjack-slf4j.rb
+++ b/slf4j/lib/rjack-slf4j.rb
@@ -224,7 +224,7 @@ module RJack
             if ex.is_a?( NativeException )
               @logger.#{lvl}( msg.to_s, ex.cause )
             elsif #{lvl}?
-              log = msg.to_s
+              log = msg.to_s.clone
               log << '\n'
               log << ex.class.name << ': ' << ex.message << '\n'
               ex.backtrace.each do |b|


### PR DESCRIPTION
rjack-sl4fj *_ex methods clone the message string before appending to it
so they don't clobber the caller's string.
