### PR TITLE
add inherit_channel attribute for rjack-jetty

### DIFF
--- a/jetty/lib/rjack-jetty.rb
+++ b/jetty/lib/rjack-jetty.rb
@@ -248,8 +248,7 @@ module RJack
           connector.host = h if h
           connector.port = opts[:port] || ( first && @port ) || 0
           connector.idle_timeout = opts[:max_idle_time_ms] || @max_idle_time_ms
-          connector.inherit_channel = [nil, false].none? { |n|
-            [n, n.inspect].include?( opts[:inherit_channel] ) }
+          connector.inherit_channel = [true, 'true'].include?(opts[:inherit_channel])
           first = false
           connector
         end

--- a/jetty/lib/rjack-jetty.rb
+++ b/jetty/lib/rjack-jetty.rb
@@ -161,10 +161,6 @@ module RJack
       # Default: true
       attr_accessor :stop_at_shutdown
 
-      # Whether connector uses a channel inherited from the JVM?
-      # Default: false
-      attr_accessor :inherit_channel
-
       # Request log output to :stderr or file name (default: nil, no log)
       attr_accessor  :request_log_file
 

--- a/jetty/lib/rjack-jetty.rb
+++ b/jetty/lib/rjack-jetty.rb
@@ -198,7 +198,6 @@ module RJack
         @webapp_contexts      = {}
         @request_log_file     = nil
         @servlet_contexts     = {}
-        @inherit_channel      = false
         @stop_at_shutdown     = true
         @connections          = nil
       end
@@ -250,7 +249,7 @@ module RJack
           connector.port = opts[:port] || ( first && @port ) || 0
           connector.idle_timeout = opts[:max_idle_time_ms] || @max_idle_time_ms
           connector.inherit_channel = [nil, false].none? { |n|
-            [n, n.inspect].include?( opts[:inherit_channel] ) } || @inherit_channel
+            [n, n.inspect].include?( opts[:inherit_channel] ) }
           first = false
           connector
         end

--- a/jetty/lib/rjack-jetty.rb
+++ b/jetty/lib/rjack-jetty.rb
@@ -161,6 +161,10 @@ module RJack
       # Default: true
       attr_accessor :stop_at_shutdown
 
+      # Whether connector uses a channel inherited from the JVM?
+      # Default: false
+      attr_accessor :inherit_channel
+
       # Request log output to :stderr or file name (default: nil, no log)
       attr_accessor  :request_log_file
 
@@ -193,6 +197,7 @@ module RJack
         @webapp_contexts      = {}
         @request_log_file     = nil
         @servlet_contexts     = {}
+        @inherit_channel      = false
         @stop_at_shutdown     = true
         @connections          = nil
       end
@@ -243,6 +248,7 @@ module RJack
           connector.host = h if h
           connector.port = opts[:port] || ( first && @port ) || 0
           connector.idle_timeout = opts[:max_idle_time_ms] || @max_idle_time_ms
+          connector.inherit_channel = opts[:inherit_channel] || @inherit_channel
           first = false
           connector
         end

--- a/jetty/lib/rjack-jetty.rb
+++ b/jetty/lib/rjack-jetty.rb
@@ -249,7 +249,8 @@ module RJack
           connector.host = h if h
           connector.port = opts[:port] || ( first && @port ) || 0
           connector.idle_timeout = opts[:max_idle_time_ms] || @max_idle_time_ms
-          connector.inherit_channel = opts[:inherit_channel] || @inherit_channel
+          connector.inherit_channel = [nil, false].none? { |n|
+            [n, n.inspect].include?( opts[:inherit_channel] ) } || @inherit_channel
           first = false
           connector
         end

--- a/jetty/lib/rjack-jetty.rb
+++ b/jetty/lib/rjack-jetty.rb
@@ -174,11 +174,16 @@ module RJack
       # :max_idle_time_ms:: See above
       # :key_store_path:: For ssl, the path to the (Java JKS) keystore
       # :key_store_password:: For ssl, the password to the keystore
+      # :inherit_channel:: Use channel based on standard input,
+      #                    if standard input is available and binded to a socket,
+      #                    it can be used for inetd or hot deploy with
+      #                    {start_server}[https://metacpan.org/pod/start_server]
       #
       # URI examples:
       #
       #  tcp://127.0.0.1
       #  ssl://0.0.0.0:8443?key_store_path=test/keystore&key_store_password=399as8d9
+      #  tcp://127.0.0.1?inherit_channel=true
       #
       attr_accessor  :connections
 

--- a/jetty/lib/rjack-jetty.rb
+++ b/jetty/lib/rjack-jetty.rb
@@ -174,10 +174,11 @@ module RJack
       # :max_idle_time_ms:: See above
       # :key_store_path:: For ssl, the path to the (Java JKS) keystore
       # :key_store_password:: For ssl, the password to the keystore
-      # :inherit_channel:: Use channel based on standard input,
+      # :inherit_channel:: If set to true, use channel based on standard input,
       #                    if standard input is available and binded to a socket,
       #                    it can be used for inetd or hot deploy with
       #                    {start_server}[https://metacpan.org/pod/start_server]
+      #                    (Default: false)
       #
       # URI examples:
       #

--- a/jetty/test/test_jetty.rb
+++ b/jetty/test/test_jetty.rb
@@ -47,6 +47,24 @@ class TestJetty < MiniTest::Unit::TestCase
     factory
   end
 
+  def test_parse_inherit_channel
+    factory = default_factory
+    factory.connections = [ 'tcp://127.0.0.1?inherit_channel=true',
+                            { scheme: 'tcp', inherit_channel: true },
+                            'tcp://127.0.0.1?inherit_channel=false',
+                            { scheme: 'tcp', inherit_channel: false },
+                            'tcp://127.0.0.1?inherit_channel=nil',
+                            { scheme: 'tcp', inherit_channel: nil } ]
+    server = factory.create
+    connectors = server.connectors
+    assert( connectors[0].inherit_channel )
+    assert( connectors[1].inherit_channel )
+    assert( !connectors[2].inherit_channel )
+    assert( !connectors[3].inherit_channel )
+    assert( !connectors[4].inherit_channel )
+    assert( !connectors[5].inherit_channel )
+  end
+
   def test_start_stop
     10.times do
       factory = default_factory


### PR DESCRIPTION
This pull request add `inherit_channel` attribute to enable hot deploy, shutdown old process after new process is listening, with [`start_server`](https://metacpan.org/pod/start_server).

Originally [`setInheritChannel`](http://download.eclipse.org/jetty/9.3.6.v20151106/apidocs/org/eclipse/jetty/server/ServerConnector.html#setInheritChannel-boolean-) for `org.eclipse.jetty.server.Connector` is for `inetd` support, but this can use for hot deploy with `server_starter` >= 0.28

[Server::Starter meets Java](http://www.slideshare.net/tokuhirom/serverstarter-meets-java) describes `start_server` and how it works with Java web application.

A hot deploy sample is following:

1. start rjack-jetty sample code with `start_server`
  ```console
$ start_server --port=8080=0 --kill-old-delay=20 -- jruby server.rb
  ```
 with `--port=8080=0` `start_server` use port `8080` and file descriptor `0` for `inherit_channel`, and with `--kill-old-delay=20`, `start_server` wait 20 seconds to kill old process.
  `server.rb` code, borrowed from `rjack-jetty` sample, is following:
  ```ruby
require 'rjack-jetty'
require 'rjack-jetty/test-servlets'

include RJack

factory = Jetty::ServerFactory.new
factory.inherit_channel = true
factory.port = 8080
factory.set_context_servlets('/', '/*' => Jetty::TestServlets::SnoopServlet.new)

server = factory.create
server.start
server.join
  ```
  
2. hot deploy with `kill -HUP`. `start_server` launch new process and kill old process.
  ```console 
$ kill -HUP {start_server pid}
  ```

I also confirmed [fishwife](https://github.com/dekellum/fishwife/), rack server using `rjack-jetty`, work with this pull request by giving `-O inherited_channel` option.